### PR TITLE
feat: adiciona validação de extensão de imagem na URL do livro

### DIFF
--- a/app/schemas/livro_schema.py
+++ b/app/schemas/livro_schema.py
@@ -1,7 +1,13 @@
-from marshmallow import Schema, fields
+from marshmallow import Schema, fields, validates, ValidationError
+import re
 
 class LivroSchema(Schema):
     titulo = fields.Str(required=True)
     categoria = fields.Str(required=True)
     autor = fields.Str(required=True)
     image_url = fields.Url(required=True, error_messages={"invalid": "URL inválida"})
+
+    @validates("image_url")
+    def validar_extensao_imagem(self, valor):
+        if not re.match(r'^https?:\/\/.+\.(jpg|jpeg|png|webp)$', valor, re.IGNORECASE):
+            raise ValidationError("A URL deve terminar com .jpg, .jpeg, .png ou .webp")


### PR DESCRIPTION
Esta solicitação pull inclui uma melhoria no `LivroSchema` no arquivo `app/schemas/livro_schema.py`. As alterações introduzem um novo método de validação para garantir que o campo `image_url` tenha uma extensão de arquivo de imagem válida.

Melhorias na validação:

* [`app/schemas/livro_schema.py`](diffhunk://#diff-0e1db4a26eea7e9df7ac6c3499d7bba3d6482661d6aff51d9e5a512bfdb31f25L1-R13): Adicionado o decorador `validates` e a classe `ValidationError` do marshmallow, e implementado um novo método `validar_extensao_imagem` para validar se `image_url` termina com `.jpg`, `.jpeg`, `.png` ou `.webp` usando uma expressão regular.